### PR TITLE
Allow null location

### DIFF
--- a/schemata.js
+++ b/schemata.js
@@ -88,7 +88,7 @@ exports.messages = {
                         "required": ["Type", "Coordinate"]
                     }
                 },
-                "required": ["Message-id", "Zone-id", "Expired-at","Created-at", "Topic", "Title", "Message"]
+                "required": ["Message-id", "Zone-id", "Expired-at","Created-at", "Topic", "Title", "Message", "Location"]
             },
             "uniqueItems": true
         }

--- a/schemata.js
+++ b/schemata.js
@@ -72,7 +72,7 @@ exports.messages = {
                         "type": "string"
                     },
                     "Location": {
-                        "type": "object",
+                        "type": ["object", "null"],
                         "properties": {
 
                             "Type": {


### PR DESCRIPTION
The attribute "Location" of a message is now required but can be null; in order to work with Java.