### PR TITLE
hide toolbar when not in editing mode

### DIFF
--- a/public/js/map.js
+++ b/public/js/map.js
@@ -5,7 +5,10 @@ var mapVue = new Vue({
   data: {
     map: null,
     layer: null,
-    button_shown: true
+    button_shown: true,
+    drawnItems: null,
+    drawControl: null,
+    tools_shown: false
   },
   // map initialization
   created: function () {
@@ -15,15 +18,21 @@ var mapVue = new Vue({
     }).addTo(map);
     this.$set('map', map);
     this.get_zones();
-    startEditing(map);
+    this.setupDrawTools();
   },
   events: {
     'switchState': function (state) {
       if (state == "addzone") {
         this.button_shown = false;
+        if (this.tools_shown == false){
+          this.startEditing()
+        }
       }
       else {
         this.button_shown = true;
+        if (this.tools_shown == true){
+          this.stopEditing()
+        }
       }
     }
   },
@@ -68,185 +77,181 @@ var mapVue = new Vue({
           })
           .addTo(this.map)
       })
+    },
+    setupDrawTools: function(){
+      this.drawnItems = new L.FeatureGroup();
+      this.map.addLayer(this.drawnItems);
+
+      L.Draw.Polygon = L.Draw.Polyline.extend({
+        statics: {
+          TYPE: 'polygon'
+        },
+
+        Poly: L.Polygon,
+
+        options: {
+          showArea: false,
+          shapeOptions: {
+            stroke: true,
+            color: '#f06eaa',
+            weight: 4,
+            opacity: 0.5,
+            fill: true,
+            fillColor: null, //same as color by default
+            fillOpacity: 0.2,
+            clickable: true
+          }
+        },
+
+        initialize: function (map, options) {
+          L.Draw.Polyline.prototype.initialize.call(this, map, options);
+
+          // Save the type so super can fire, need to do this as cannot do this.TYPE :(
+          this.type = L.Draw.Polygon.TYPE;
+        },
+
+        _updateFinishHandler: function () {
+          var markerCount = this._markers.length;
+
+          // The first marker should have a click handler to close the polygon
+          if (markerCount === 1) {
+            this._markers[0].on('click', this._finishShape, this);
+          }
+
+          // Add and update the double click handler
+          if (markerCount > 2) {
+            this._markers[markerCount - 1].on('dblclick', this._finishShape, this);
+            // Only need to remove handler if has been added before
+            if (markerCount > 3) {
+              this._markers[markerCount - 2].off('dblclick', this._finishShape, this);
+            }
+          }
+        },
+
+        _getTooltipText: function () {
+          var text, subtext;
+
+          if (this._markers.length === 0) {
+            text = L.drawLocal.draw.handlers.polygon.tooltip.start;
+          } else if (this._markers.length < 3) {
+            text = L.drawLocal.draw.handlers.polygon.tooltip.cont;
+          } else {
+            text = L.drawLocal.draw.handlers.polygon.tooltip.end;
+            subtext = this._getMeasurementString();
+          }
+
+          return {
+            text: text,
+            subtext: subtext
+          };
+        },
+
+        _getMeasurementString: function () {
+          var area = this._area;
+
+          if (!area) {
+            return null;
+          }
+
+          return L.GeometryUtil.readableArea(area, this.options.metric);
+        },
+
+        _shapeIsValid: function () {
+          return this._markers.length >= 3;
+        },
+
+        _vertexChanged: function (latlng, added) {
+          var latLngs;
+
+          // Check to see if we should show the area
+          if (!this.options.allowIntersection && this.options.showArea) {
+            latLngs = this._poly.getLatLngs();
+
+            this._area = L.GeometryUtil.geodesicArea(latLngs);
+          }
+
+          L.Draw.Polyline.prototype._vertexChanged.call(this, latlng, added);
+        },
+
+        _cleanUpShape: function () {
+          var markerCount = this._markers.length;
+
+          if (markerCount > 0) {
+            this._markers[0].off('click', this._finishShape, this);
+
+            if (markerCount > 2) {
+              this._markers[markerCount - 1].off('dblclick', this._finishShape, this);
+            }
+          }
+        }
+      });
+
+      L.DrawToolbar.include({
+        getModeHandlers: function (map) {
+          return [{
+            enabled: true,
+            handler: new L.Draw.Polygon(map, this.options.polygon),
+            title: 'Draw a Polygon',
+            id: 'drawP'
+          }];
+        }
+      });
+      // control element
+      this.drawControl = new L.Control.Draw({
+        position: 'topright',
+        draw: {
+
+          polygon: {
+            allowIntersection: false,
+            showArea: true,
+            drawError: {
+              color: '#b00b00',
+              timeout: 1000
+            },
+            shapeOptions: {
+              stroke: true,
+              color: '#f06eaa',
+              weight: 4,
+              opacity: 0.5,
+              fill: true,
+              fillColor: null, //same as color by default
+              fillOpacity: 0.2,
+              clickable: false
+            }
+          }
+        },
+        edit: {
+          featureGroup: this.drawnItems
+        }
+      });
+
+      this.map.on('draw:created', function (e) {
+        var type = e.layerType,
+          layer = e.layer;
+
+        if (type === 'polygon') {
+          coordinates = [];
+          LatLongs = layer.getLatLngs();
+          for (i = 0; i < LatLongs.length; i++) {
+            coordinates.push([LatLongs[i].lat, LatLongs[i].lng]);
+          }
+          document.getElementById("area").value = coordinates;
+        }
+        // Do whatever else you need to. (save to db, add to map etc)
+      });
+    },
+    startEditing: function(){
+      this.drawControl.addTo(this.map)
+      this.tools_shown = true;
+    },
+    stopEditing: function(){
+      this.drawControl.removeFrom(this.map)
+      this.tools_shown = false;
     }
   }
 });
 
-// function for handling the drawing of polygons on the map
-function startEditing(map) {
-  var drawnItems = new L.FeatureGroup();
-  map.addLayer(drawnItems);
 
-  L.Draw.Polygon = L.Draw.Polyline.extend({
-    statics: {
-      TYPE: 'polygon'
-    },
-
-    Poly: L.Polygon,
-
-    options: {
-      showArea: false,
-      shapeOptions: {
-        stroke: true,
-        color: '#f06eaa',
-        weight: 4,
-        opacity: 0.5,
-        fill: true,
-        fillColor: null, //same as color by default
-        fillOpacity: 0.2,
-        clickable: true
-      }
-    },
-
-    initialize: function (map, options) {
-      L.Draw.Polyline.prototype.initialize.call(this, map, options);
-
-      // Save the type so super can fire, need to do this as cannot do this.TYPE :(
-      this.type = L.Draw.Polygon.TYPE;
-    },
-
-    _updateFinishHandler: function () {
-      var markerCount = this._markers.length;
-
-      // The first marker should have a click handler to close the polygon
-      if (markerCount === 1) {
-        this._markers[0].on('click', this._finishShape, this);
-      }
-
-      // Add and update the double click handler
-      if (markerCount > 2) {
-        this._markers[markerCount - 1].on('dblclick', this._finishShape, this);
-        // Only need to remove handler if has been added before
-        if (markerCount > 3) {
-          this._markers[markerCount - 2].off('dblclick', this._finishShape, this);
-        }
-      }
-    },
-
-    _getTooltipText: function () {
-      var text, subtext;
-
-      if (this._markers.length === 0) {
-        text = L.drawLocal.draw.handlers.polygon.tooltip.start;
-      } else if (this._markers.length < 3) {
-        text = L.drawLocal.draw.handlers.polygon.tooltip.cont;
-      } else {
-        text = L.drawLocal.draw.handlers.polygon.tooltip.end;
-        subtext = this._getMeasurementString();
-      }
-
-      return {
-        text: text,
-        subtext: subtext
-      };
-    },
-
-    _getMeasurementString: function () {
-      var area = this._area;
-
-      if (!area) {
-        return null;
-      }
-
-      return L.GeometryUtil.readableArea(area, this.options.metric);
-    },
-
-    _shapeIsValid: function () {
-      return this._markers.length >= 3;
-    },
-
-    _vertexChanged: function (latlng, added) {
-      var latLngs;
-
-      // Check to see if we should show the area
-      if (!this.options.allowIntersection && this.options.showArea) {
-        latLngs = this._poly.getLatLngs();
-
-        this._area = L.GeometryUtil.geodesicArea(latLngs);
-      }
-
-      L.Draw.Polyline.prototype._vertexChanged.call(this, latlng, added);
-    },
-
-    _cleanUpShape: function () {
-      var markerCount = this._markers.length;
-
-      if (markerCount > 0) {
-        this._markers[0].off('click', this._finishShape, this);
-
-        if (markerCount > 2) {
-          this._markers[markerCount - 1].off('dblclick', this._finishShape, this);
-        }
-      }
-    }
-  });
-
-  L.DrawToolbar.include({
-    getModeHandlers: function (map) {
-      return [{
-        enabled: true,
-        handler: new L.Draw.Polygon(map, this.options.polygon),
-        title: 'Draw a Polygon',
-        id: 'drawP'
-      }];
-    }
-  });
-  // control element
-  var drawControl = new L.Control.Draw({
-    position: 'topright',
-    draw: {
-
-      polygon: {
-        allowIntersection: false,
-        showArea: true,
-        drawError: {
-          color: '#b00b00',
-          timeout: 1000
-        },
-        shapeOptions: {
-          stroke: true,
-          color: '#f06eaa',
-          weight: 4,
-          opacity: 0.5,
-          fill: true,
-          fillColor: null, //same as color by default
-          fillOpacity: 0.2,
-          clickable: false
-        }
-      }
-    },
-    edit: {
-      featureGroup: drawnItems
-    }
-  });
-
-  map.addControl(drawControl);
-
-  map.on('draw:created', function (e) {
-    var type = e.layerType,
-      layer = e.layer;
-
-    if (type === 'polygon') {
-      coordinates = [];
-      LatLongs = layer.getLatLngs();
-      for (i = 0; i < LatLongs.length; i++) {
-        coordinates.push([LatLongs[i].lat, LatLongs[i].lng]);
-      }
-      document.getElementById("area").value = coordinates;
-    }
-    // Do whatever else you need to. (save to db, add to map etc)
-    drawnItems.addLayer(layer);
-  });
-
-  map.on('draw:edited', function () {
-    // Update db to save latest changes.
-  });
-
-  map.on('draw:deleted', function () {
-    delete (layer)
-    // Update db to save latest changes.
-  });
-}
 
 // function for processing clicks on zones on the map and handling overlapping zones
 function processClick(lat, lng) {


### PR DESCRIPTION
Here I tried to hide the toolbar when ever we are not in the create zone part. I think that is important. Sadly a side effect of my changes is that the zone is not displayed after you finish drawing it. It is put into the field for the zone input and disappears. That is not that nice. In opinion though it closes a lot of possible holes in the overall usage of the site. Well you all can checkout the branch an have a look. It does not have to be merged.